### PR TITLE
Ocultar aba para testadores e correção de duplicação

### DIFF
--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -16,7 +16,7 @@
 
     <div class="card-panel white z-depth-2">
         <div class="row center-align">
-            <div th:if="${isAuthenticated}" class="col s12" style="margin-bottom: 15px;">
+            <div th:if="${isAdmin}" class="col s12" style="margin-bottom: 15px;">
                 <a href="/users" class="btn-large blue waves-effect manage-btn" style="width: 350px;">Gerenciar Usuários</a>
             </div>
             <div th:if="${isAuthenticated}" class="col s12" style="margin-bottom: 15px;">

--- a/src/main/resources/templates/project/form.html
+++ b/src/main/resources/templates/project/form.html
@@ -61,14 +61,6 @@
 </script>
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
-<script>
-    $(document).ready(function () {
-        $('.select2').select2({
-            width: '100%',
-            placeholder: 'Selecione os membros',
-            allowClear: true
-        });
-    });
-</script>
+
 </body>
 </html>


### PR DESCRIPTION
Aba 'gerenciar usuários' fica oculta para testadores.
Alteração no código para remover duplicação no campo de membros na criação de projetos.